### PR TITLE
Conform Corredor err handling with API stack traces

### DIFF
--- a/src/scripts/parser.ts
+++ b/src/scripts/parser.ts
@@ -94,9 +94,6 @@ export default class ScriptParser {
       s.description = o.description
     }
 
-    const hasTriggers = !Object.prototype.hasOwnProperty.call(o, 'triggers')
-    const hasIterator = !Object.prototype.hasOwnProperty.call(o, 'iterator')
-
     if (Object.prototype.hasOwnProperty.call(o, 'iterator') && o.iterator) {
       s.iterator = MakeIterator(o.iterator) ?? undefined
       if (!s.iterator) {


### PR DESCRIPTION
API, when in debug mode, returns an array of objects representing the stack trace.
Internal errors define the classic string stack trace.

This patch adds support for both formats.