### PR TITLE
Migrate docker image to node:fermium-bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.14-alpine
+FROM node:fermium-bullseye-slim
 
 ENV PATH /corredor/node_modules/.bin:$PATH
 
@@ -22,7 +22,7 @@ ENV CORREDOR_EXEC_CSERVERS_API_BASEURL_TEMPLATE "http://server/api/{service}"
 
 WORKDIR /corredor
 
-RUN apk update && apk add --no-cache git
+RUN apt-get update && apt-get -y install git
 
 COPY package.json ./
 COPY yarn.lock ./


### PR DESCRIPTION
Migration to [`node:fermium-bullseye-slim`](https://hub.docker.com/layers/node/library/node/fermium-bullseye-slim/images/sha256-5cf1311d81728b3ba38242a82126510340fcdc5e1b156e78f27245229f36ac60?context=explore)
fermium -> node 14.x.x
bullseye -> debian 11.x

Why Debian ?
Because it's an official image from node on dockerhub, it is safer/easier than trying to tinker a node docker image ourselve.

This migration allow us to benefit from more standard libraries while avoiding the constraint of Musl.

Only cons I saw, the image is a bit heavier (`~222.8MB` compressed instead of `152.81MB` for the [2021.9.3](https://hub.docker.com/layers/cortezaproject/corteza-server-corredor/2021.9.3/images/sha256-3c5fbad62897ece6f77b5fa0f7b38e019f92c67e005384d1c68a25a65bb733b4?context=explore))

Tested with a 2021.9.3 server, didn't encounter any issue.