### PR TITLE
Optimize Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV CORREDOR_EXEC_CSERVERS_API_BASEURL_TEMPLATE "http://server/api/{service}"
 
 WORKDIR /corredor
 
-RUN apt-get update && apt-get -y install git netcat
+RUN apt-get update && apt-get -y install git netcat && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY package.json ./
 COPY yarn.lock ./


### PR DESCRIPTION
Adding `apt-get clean` is recommended after installing packages in a `Dockerfile` to help keep the image as small as possible. When you install packages with `apt-get install`, the process generates cached files and package metadata that aren't needed after installation. Using `apt-get clean` and `rm -rf /var/lib/apt/lists/*` removes these files, reducing image size.