### PR TITLE
String startsWith

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -67,7 +67,7 @@ function discoverFrontendBaseURL (): string {
 
 export const env = (e.CORREDOR_ENVIRONMENT ?? e.CORREDOR_ENV ?? e.NODE_ENV ?? 'prod').trim().toLowerCase()
 
-export const isDevelopment = env.indexOf('dev') === 0
+export const isDevelopment = env.startsWith('dev')
 export const isProduction = !isDevelopment
 
 const certPath = e.CORREDOR_SERVER_CERTIFICATES_PATH ?? '/certs'

--- a/src/services/dependencies.ts
+++ b/src/services/dependencies.ts
@@ -91,7 +91,7 @@ export default class Dependencies {
     //
     Object
       .getOwnPropertyNames(require.cache)
-      .filter(path => path.substr(0, nmdir.length) === nmdir)
+      .filter(path => path.startsWith(nmdir))
       .forEach((filename) => {
         delete require.cache[filename]
       })

--- a/src/services/shared/filter.ts
+++ b/src/services/shared/filter.ts
@@ -25,7 +25,7 @@ export default function (f: ListFilter): {(Script): boolean} {
       const tt = (item.triggers || []).filter(({ resourceTypes, eventTypes }: TriggerFilterArgs) => {
         if (f.resourceType && f.resourceType.length > 0) {
           // Filter by resource
-          if (!resourceTypes || resourceTypes.indexOf(f.resourceType) === -1) {
+          if (!resourceTypes || !resourceTypes.includes(f.resourceType)) {
             // No resources found on trigger
             return false
           }
@@ -33,7 +33,7 @@ export default function (f: ListFilter): {(Script): boolean} {
 
         if (f.eventTypes && f.eventTypes.length > 0) {
           // Filter by events
-          if (!eventTypes || f.eventTypes.find(fe => (eventTypes.indexOf(fe) > -1)) === undefined) {
+          if (!eventTypes || f.eventTypes.find(fe => eventTypes.includes(fe)) === undefined) {
             return false
           }
         }
@@ -54,7 +54,7 @@ export default function (f: ListFilter): {(Script): boolean} {
 
       // search query terms
       for (const t of f.query.split(' ')) {
-        if (str.indexOf(t) > -1) {
+        if (str.includes(t)) {
           return true
         }
       }


### PR DESCRIPTION
JavaScript nowadays provides `str.startsWith(prefix)` which is more readable than `str.indexOf(prefix) === 0`.
Similarly, `str.includes(substr)` is more readable than `str.indexOf(substr) > -1`.

Also `str.substr(...)` is deprecated. 