### PR TITLE
function types

### DIFF
--- a/src/services/dependencies.ts
+++ b/src/services/dependencies.ts
@@ -9,9 +9,7 @@ interface CtorArgs {
   searchPaths: string[];
 }
 
-interface WatchCallback {
-  (path: string): void;
-}
+type WatchCallback = (path: string) => void
 
 /**
  * Utility function for flatting w/ Array.reduce

--- a/src/services/shared/filter.ts
+++ b/src/services/shared/filter.ts
@@ -14,7 +14,7 @@ interface TriggerFilterArgs {
 /**
  * Creates Array.filter() compatible function for filtering script array
  */
-export default function (f: ListFilter): {(Script): boolean} {
+export default function (f: ListFilter): ((item: Script) => boolean) {
   return (item: Script): boolean => {
     if (f === undefined) {
       // Match all when no filter

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,9 +58,7 @@ export interface ScriptSecurity {
   allow: string[];
 }
 
-export interface ScriptFn {
-  (args: exec.Args, ctx?: exec.Ctx): unknown;
-}
+export type ScriptFn = (args: exec.Args, ctx?: exec.Ctx) => unknown
 
 export interface Watcher {
   watch (): void;


### PR DESCRIPTION
At least `{(Script): boolean}` should be fixed to `{(item: Script): boolean}`. 

But according to [SonarQube](https://next.sonarqube.com/sonarqube/coding_rules?open=typescript%3AS6598&rule_key=typescript%3AS6598), all these call signatures should be replaced with function types.