### PR TITLE
Update dockerfile and bump corteza-js version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:22
+FROM node:22-slim
 
-ENV PATH /corredor/node_modules/.bin:$PATH
+ENV PATH=/corredor/node_modules/.bin:$PATH
 
 # GRPC's env-vars
 # https://github.com/grpc/grpc/blob/master/doc/environment_variables.md
@@ -18,7 +18,7 @@ ENV CORREDOR_EXT_CLIENT_SCRIPTS_WATCH=false
 ENV CORREDOR_EXT_SEARCH_PATHS=/corredor/usr/*:/corredor/usr
 # This assumes that container will be part of the docker-compose setup were corteza is
 # ran under "server" service and can be directly accessed via internal docker network
-ENV CORREDOR_EXEC_CSERVERS_API_BASEURL_TEMPLATE "http://server/api/{service}"
+ENV CORREDOR_EXEC_CSERVERS_API_BASEURL_TEMPLATE="http://server/api/{service}"
 
 WORKDIR /corredor
 
@@ -40,4 +40,3 @@ VOLUME /corredor/certs
 HEALTHCHECK --interval=30s --start-period=1m --timeout=30s --retries=3 CMD nc -z -v localhost 80
 
 CMD ["tsx", "src/server.ts"]
-

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cdeps": "yarn upgrade @cortezaproject/corteza-js https://github.com/cortezaproject/corteza-protobuf#develop"
   },
   "dependencies": {
-    "@cortezaproject/corteza-js": "^2024.9.2-dev.1",
+    "@cortezaproject/corteza-js": "^2024.9.2-dev.2",
     "@cortezaproject/corteza-protobuf": "https://github.com/cortezaproject/corteza-protobuf#develop",
     "@grpc/grpc-js": "^1.12.6",
     "@grpc/proto-loader": "^0.7.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@cortezaproject/corteza-js@^2024.9.2-dev.1":
-  version "2024.9.2-dev.1"
-  resolved "https://registry.yarnpkg.com/@cortezaproject/corteza-js/-/corteza-js-2024.9.2-dev.1.tgz#87d73bd41ab815e2bc0eb914329fcf801c6e4eda"
-  integrity sha512-PiEGTnfVz54G2z9nC/weMftTVmzNfMPIZXhMon+hVAvL9uigqZ7hRukV4iFn0jADe+nLy1dibXXc2K1Rgi+SSw==
+"@cortezaproject/corteza-js@^2024.9.2-dev.2":
+  version "2024.9.2-dev.2"
+  resolved "https://registry.yarnpkg.com/@cortezaproject/corteza-js/-/corteza-js-2024.9.2-dev.2.tgz#236792571cf8393db4af53facdbde09c33677b3f"
+  integrity sha512-QjNc0Ob/exmUCAxMBBIqX9RRO9OcR7f6iXgCfJc2GwXiuENg6oI1W+dXSRG4ccv41YcNMHoegZlCGiKdFGAeAg==
   dependencies:
     axios "^1.7.9"
     hex-rgb "^5.0.0"


### PR DESCRIPTION
Updated the dockerfile. Fixed the deprecated syntax and also changed the base image. Use node:22-slim instead of node:22 as it shrinks the final img's size by 700mb.